### PR TITLE
chore: 更新依赖版本并优化关于页面与资源解析逻辑

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -37,20 +37,22 @@ kotlin {
     jvmToolchain {
         languageVersion.set(javaLanguageVersion)
     }
-    
+
     // Target configuration
     jvm()
-    
+
     // Source sets
     sourceSets {
         // Common dependencies
         commonMain.dependencies {
             implementation(projects.shared)
         }
-        
+
         // JVM-specific dependencies
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.coroutines.swing)
         }
     }
 }
@@ -105,14 +107,14 @@ compose.desktop {
                 TargetFormat.Deb,   // Debian/Ubuntu
                 TargetFormat.Rpm    // RedHat/Fedora
             )
-            
+
             // Application metadata
             packageName = kitPackageName
             packageVersion = kitVersion
             description = kitDescription
             copyright = kitCopyright
             vendor = kitVendor
-            
+
             // Required JVM modules
             modules(
                 "java.compiler",
@@ -139,7 +141,7 @@ compose.desktop {
                 debMaintainer = "lazyiones@gmail.com"
                 iconFile.set(project.file("launcher/icon.png"))
             }
-            
+
             // macOS-specific configuration
             macOS {
                 dmgPackageVersion = packageVersion
@@ -157,7 +159,7 @@ compose.desktop {
                     this.extraKeysRawXml = macExtraPlistKeys
                 }
             }
-            
+
             // Windows-specific configuration
             windows {
                 msiPackageVersion = packageVersion
@@ -172,10 +174,10 @@ compose.desktop {
                 iconFile.set(project.file("launcher/icon.ico"))
             }
         }
-        
+
         // ProGuard configuration for release builds
         buildTypes.release.proguard {
-            version.set("7.8.2")
+            version.set("7.9.1")
             obfuscate.set(true)
             optimize.set(true)
             joinOutputJars.set(true)

--- a/composeApp/compose-desktop.pro
+++ b/composeApp/compose-desktop.pro
@@ -64,7 +64,7 @@
 -keepclassmembers enum * { public static **[] values(); public static ** valueOf(java.lang.String); }
 
 # 保留 Kotlin 元数据（若使用 Kotlin）
--keep class kotlin.Metadata { *; }
+#-keep class kotlin.Metadata { *; }
 
 # 忽略第三方库警告
 -dontwarn com.google.common.**
@@ -83,3 +83,36 @@
 -dontnote io.ktor.**
 -dontnote org.slf4j.**
 -dontnote kotlinx.serialization.**
+
+# dbus-java
+-keep class org.freedesktop.dbus.** { *; }
+-keep class io.github.vinceglb.filekit.dialogs.platform.xdg.** { *; }
+-keepattributes Signature,InnerClasses,RuntimeVisibleAnnotations
+
+# kotlinx.coroutines
+-keep class kotlinx.coroutines.** { *; }
+-keep class kotlinx.coroutines.internal.MainDispatcherFactory { *; }
+-keep class kotlinx.coroutines.swing.SwingDispatcherFactory { *; }
+
+# Allow R8 to optimize away the FastServiceLoader.
+# Together with ServiceLoader optimization in R8
+# this results in direct instantiation when loading Dispatchers.Main
+-assumenosideeffects class kotlinx.coroutines.internal.MainDispatcherLoader {
+    boolean FAST_SERVICE_LOADER_ENABLED return false;
+}
+
+-assumenosideeffects class kotlinx.coroutines.internal.FastServiceLoaderKt {
+    boolean ANDROID_DETECTED return true;
+}
+
+# Disable support for "Missing Main Dispatcher", since we always have Android main dispatcher
+-assumenosideeffects class kotlinx.coroutines.internal.MainDispatchersKt {
+    boolean SUPPORT_MISSING return false;
+}
+
+# Statically turn off all debugging facilities and assertions
+-assumenosideeffects class kotlinx.coroutines.DebugKt {
+    boolean getASSERTIONS_ENABLED() return false;
+    boolean getDEBUG() return false;
+    boolean getRECOVER_STACK_TRACES() return false;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ development=true
 # ========================================
 # Application Properties
 # ========================================
-kitVersion=1.6.10
+kitVersion=1.6.11
 kitPackageName=AndroidToolKit
 kitDescription=Desktop tools applicable to Android development, supporting Windows, Mac and Linux
 kitCopyright=Copyright (c) 2024 LazyIonEs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,36 +1,37 @@
 [versions]
 compose = "1.4.0"
 compose-compiler = "1.5.8"
-compose-plugin = "1.11.0"
+compose-plugin = "1.11.1"
 compose-material3 = "1.11.0-alpha07"
 navigation3 = "1.1.1"
 savedstate = "1.4.0"
 icons = "1.7.3"
 adaptive = "1.3.0-alpha07"
-lifecycle = "2.11.0-beta01"
+lifecycle = "2.11.0-beta02"
 junit = "4.13.2"
-kotlin = "2.3.21"
-apksig = "8.11.1"
-tools = "31.11.1"
-slf4j = "2.0.17"
-buildconfig = "6.0.9"
-commons-codec = "1.21.0"
-asm = "9.10"
-jna = "5.18.1"
-logging = "8.0.02"
+kotlin = "2.4.0"
+apksig = "8.11.2"
+guava = "33.3.1-jre"
+tools = "32.2.1"
+slf4j = "2.0.18"
+buildconfig = "6.0.10"
+commons-codec = "1.22.0"
+asm = "9.10.1"
+jna = "5.19.1"
+logging = "8.0.4"
 coroutines = "1.11.0"
-filekit = "0.14.1"
+filekit = "0.14.2"
 multiplatform-settings = "1.3.0"
 kotlinx-serialization-json = "1.11.0"
 kotlinx-datetime = "0.8.0"
-about-libraries = "14.2.1"
-coil = "3.4.0"
-zoomimage = "1.4.0"
+about-libraries = "15.0.0"
+coil = "3.5.0"
+zoomimage = "1.5.0-beta02"
 apktool = "2.12.1"
 ktor = "3.5.0"
-markdown = "0.41.0"
-logback = "1.5.32"
-compottie = "2.1.0"
+markdown = "0.42.0"
+logback = "1.5.34"
+compottie = "2.2.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -55,6 +56,8 @@ lifecycle-viewmodel-navigation3 = { module = "org.jetbrains.androidx.lifecycle:l
 android-apksig = { module = "com.android.tools.build:apksig", version.ref = "apksig" }
 # https://mvnrepository.com/artifact/com.android.tools/sdk-common
 android-sdk-common = { module = "com.android.tools:sdk-common", version.ref = "tools" }
+# https://mvnrepository.com/artifact/com.google.guava/guava
+google-guava = { module = "com.google.guava:guava", version.ref = "guava" }
 # https://mvnrepository.com/artifact/com.android.tools.apkparser/binary-resources
 android-binary-resources = { module = "com.android.tools.apkparser:binary-resources", version.ref = "tools" }
 # https://mvnrepository.com/artifact/org.slf4j/slf4j-api
@@ -72,6 +75,7 @@ logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "loggin
 logback-core = { module = "ch.qos.logback:logback-core", version.ref = "logback" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 # https://github.com/Kotlin/kotlinx.coroutines
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "coroutines" }
 # https://github.com/vinceglb/FileKit
 filekit-core = { module = "io.github.vinceglb:filekit-core", version.ref = "filekit" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -8,8 +8,8 @@ crate-type = ["cdylib"]
 name = "toolkit_rs"
 
 [dependencies]
-uniffi = { version = "0.31.0", features = [ "cli" ] }
-image = "0.25.9"
+uniffi = { version = "0.31.2", features = [ "cli" ] }
+image = "0.25.10"
 imagequant = "4.4.1"
 thiserror = "2.0.18"
 lodepng = "3.12.1"
@@ -17,10 +17,10 @@ fast_image_resize = { version = "6.0.0", features = ["image"] }
 mozjpeg = "0.10.13"
 oxipng = { version = "10.1.0", features = ["parallel", "zopfli"], default-features = false }
 rgb = { version = "0.8.52", default-features = false }
-resize = "0.8.8"
+resize = "0.8.9"
 
 [build-dependencies]
-uniffi = { version = "0.31.0", features = ["build"] }
+uniffi = { version = "0.31.2", features = ["build"] }
 
 [[bin]]
 name = "uniffi-bindgen"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -84,6 +84,7 @@ kotlin {
             // Android tools (with exclusions to avoid conflicts)
             implementation(libs.android.apksig)
             implementation(libs.android.sdk.common)
+            implementation(libs.google.guava)
             implementation(libs.android.binary.resources)
 
             // Third-party libraries
@@ -157,7 +158,8 @@ kotlin {
         // JVM-specific dependencies
         jvmMain.dependencies {
             implementation(compose.desktop.currentOs)
-            runtimeOnly(libs.kotlinx.coroutines.swing)
+            implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.coroutines.swing)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/org/tool/kit/feature/setting/SetUp.kt
+++ b/shared/src/commonMain/kotlin/org/tool/kit/feature/setting/SetUp.kt
@@ -7,14 +7,12 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -35,13 +33,10 @@ import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.ToggleButton
 import androidx.compose.material3.ToggleButtonDefaults
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -56,10 +51,9 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.rememberWindowState
-import com.mikepenz.aboutlibraries.entity.Library
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 import com.mikepenz.aboutlibraries.ui.compose.produceLibraries
-import com.mikepenz.aboutlibraries.ui.compose.util.htmlReadyLicenseContent
+import com.mikepenz.aboutlibraries.ui.compose.variant.LibraryDetailMode
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
@@ -107,13 +101,12 @@ import org.tool.kit.shared.generated.resources.version_information
 import org.tool.kit.shared.generated.resources.view_log_file
 import org.tool.kit.shared.generated.resources.whether_to_always_show_the_navigation_bar_label
 import org.tool.kit.shared.generated.resources.whether_to_turn_off_file_alignment_function_when_signing_and_packaging_huawei_channel_package
-import org.tool.kit.theme.AppTheme
 import org.tool.kit.utils.browseFileDirectory
 import org.tool.kit.utils.getLogFile
 import org.tool.kit.vm.MainViewModel
 import java.awt.Desktop
 import java.io.File
-import java.net.URI
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * @Author      : LazyIonEs
@@ -542,7 +535,7 @@ private fun DeveloperMode(viewModel: MainViewModel) {
 private fun About(viewModel: MainViewModel) {
     var isOpenLibraries by remember { mutableStateOf(false) }
     if (isOpenLibraries) {
-        AboutLibrariesWindow(viewModel) {
+        AboutLibrariesWindow {
             isOpenLibraries = false
         }
     }
@@ -631,7 +624,7 @@ fun VersionInfo(
                 tapCount = 0
             } else {
                 coroutineScope.launch {
-                    delay(tapTimeoutMillis)
+                    delay(tapTimeoutMillis.milliseconds)
                     tapCount = 0
                 }
             }
@@ -696,9 +689,8 @@ private fun ClickAbout(text: String, onClick: () -> Unit) {
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AboutLibrariesWindow(viewModel: MainViewModel, onCloseRequest: () -> Unit) {
+private fun AboutLibrariesWindow(onCloseRequest: () -> Unit) {
     val windowState = rememberWindowState(size = DpSize(800.dp, 600.dp))
     Window(
         onCloseRequest = onCloseRequest,
@@ -707,71 +699,14 @@ private fun AboutLibrariesWindow(viewModel: MainViewModel, onCloseRequest: () ->
         icon = painterResource(Res.drawable.icon),
         alwaysOnTop = true
     ) {
-        val themeConfig by viewModel.themeConfig.collectAsState()
-        val useDarkTheme = when (themeConfig) {
-            DarkThemeConfig.LIGHT -> false
-            DarkThemeConfig.DARK -> true
-            DarkThemeConfig.FOLLOW_SYSTEM -> isSystemInDarkTheme()
-        }
         val libraries by produceLibraries {
             Res.readBytes("files/aboutlibraries.json").decodeToString()
         }
-        AppTheme(useDarkTheme) {
-            Surface(color = MaterialTheme.colorScheme.background) {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    var selectLibrary by remember { mutableStateOf<Library?>(null) }
-                    LibrariesContainer(
-                        libraries = libraries,
-                        modifier = Modifier.fillMaxWidth(),
-                        showAuthor = false,
-                        showDescription = true,
-                        onLibraryClick = { library ->
-                            val license = library.licenses.firstOrNull()
-                            if (!license?.htmlReadyLicenseContent.isNullOrBlank()) {
-                                selectLibrary = library
-                            } else if (!license?.url.isNullOrBlank()) {
-                                license.url?.also {
-                                    Desktop.getDesktop().browse(URI.create(it))
-                                }
-                            }
-                        }
-                    )
-                    selectLibrary?.let { library ->
-                        val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-                        ModalBottomSheet(
-                            modifier = Modifier.fillMaxHeight()
-                                .align(Alignment.BottomEnd),
-                            sheetState = sheetState,
-                            onDismissRequest = { selectLibrary = null }
-                        ) {
-                            LazyColumn(
-                                modifier = Modifier.fillMaxWidth()
-                                    .padding(horizontal = 16.dp),
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                item {
-                                    Text(
-                                        text = library.name,
-                                        style = MaterialTheme.typography.titleMedium
-                                    )
-                                }
-                                item {
-                                    Spacer(Modifier.size(8.dp))
-                                    val license = library.licenses.firstOrNull()
-                                    license?.licenseContent?.let { content ->
-                                        Text(
-                                            text = content,
-                                            style = MaterialTheme.typography.bodyMedium
-                                        )
-                                    }
-                                    Spacer(Modifier.size(16.dp))
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        LibrariesContainer(
+            libraries = libraries,
+            modifier = Modifier.fillMaxSize(),
+            detailMode = LibraryDetailMode.Sheet
+        )
     }
 }
 

--- a/shared/src/commonMain/kotlin/org/tool/kit/utils/ArscBlamer.kt
+++ b/shared/src/commonMain/kotlin/org/tool/kit/utils/ArscBlamer.kt
@@ -1,0 +1,220 @@
+package org.tool.kit.utils
+
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.common.collect.HashMultimap
+import com.google.common.collect.Multimap
+import com.google.common.collect.Multimaps
+import com.google.devrel.gmscore.tools.apk.arsc.PackageChunk
+import com.google.devrel.gmscore.tools.apk.arsc.ResourceTableChunk
+import com.google.devrel.gmscore.tools.apk.arsc.ResourceValue
+import com.google.devrel.gmscore.tools.apk.arsc.TypeChunk
+import java.util.Collections
+
+/**
+ * Analyzes an APK to:
+ *
+ * <ul>
+ * <li>Blame resource configurations on their entry count (entries keeping the config around).
+ * <li>Blame strings in resources.arsc that have no base configuration.
+ * <li>Blame resources on their different configurations.
+ * </ul>
+ */
+class ArscBlamer(private val resourceTable: ResourceTableChunk) {
+
+    /** Maps package key pool indices to blamed resources. */
+    private val keyToBlame = HashMap<PackageChunk, Array<ArrayList<ResourceEntry>>>()
+
+    /** Maps types to blamed resources. */
+    private val typeToBlame = HashMap<PackageChunk, Array<ArrayList<ResourceEntry>>>()
+
+    /** Maps package to blamed resources. */
+    private val packageToBlame: Multimap<PackageChunk, ResourceEntry> = HashMultimap.create()
+
+    /** Maps string indices to blamed resources. */
+    private val stringToBlame: Array<ArrayList<ResourceEntry>> = createEntryListArray(resourceTable.stringPool.stringCount)
+
+    /** Maps type chunk entries to blamed resources. */
+    private val typeEntryToBlame: Multimap<TypeChunk.Entry, ResourceEntry> = HashMultimap.create()
+
+    /** Maps resources to the type chunk entries they reference. */
+    private var resourceEntries: Multimap<ResourceEntry, TypeChunk.Entry>? = null
+
+    /** Maps resources which have no base config to the type chunk entries they reference. */
+    private var baselessKeys: Multimap<ResourceEntry, TypeChunk.Entry>? = null
+
+    /** Contains all of the type chunks in [resourceTable]. */
+    private var typeChunks: List<TypeChunk>? = null
+
+    /** Generates blame mappings. */
+    fun blame() {
+        val entries = getResourceEntries()
+        for ((resourceEntry, chunkEntries) in entries.asMap()) {
+            val packageChunk = checkNotNull(resourceTable.getPackages(resourceEntry.packageName).getOrNull(0))
+            val keyCount = packageChunk.keyStringPool.stringCount
+            val typeCount = packageChunk.typeStringPool.stringCount
+
+            for (chunkEntry in chunkEntries) {
+                blameKeyOrType(keyToBlame, packageChunk, chunkEntry.keyIndex(), resourceEntry, keyCount)
+                blameKeyOrType(typeToBlame, packageChunk, chunkEntry.parent().id - 1, resourceEntry, typeCount)
+                blameFromTypeChunkEntry(chunkEntry)
+            }
+            blamePackage(packageChunk, resourceEntry)
+        }
+
+        Multimaps.invertFrom(entries, typeEntryToBlame)
+        for (entry in typeEntryToBlame.keySet()) {
+            blameFromTypeChunkEntry(entry)
+        }
+    }
+
+    private fun blameKeyOrType(
+        keyOrType: MutableMap<PackageChunk, Array<ArrayList<ResourceEntry>>>,
+        packageChunk: PackageChunk,
+        keyIndex: Int,
+        entry: ResourceEntry,
+        entryCount: Int
+    ) {
+        val array = keyOrType.getOrPut(packageChunk) { createEntryListArray(entryCount) }
+        array[keyIndex].add(entry)
+    }
+
+    private fun blamePackage(packageChunk: PackageChunk, entry: ResourceEntry) {
+        packageToBlame.put(packageChunk, entry)
+    }
+
+    private fun blameFromTypeChunkEntry(chunkEntry: TypeChunk.Entry) {
+        for (value in getAllResourceValues(chunkEntry)) {
+            for (entry in typeEntryToBlame.get(chunkEntry)) {
+                // 假设 ResourceValue.Type 是一个枚举
+                if (value.type() == ResourceValue.Type.STRING) {
+                    blameString(value.data(), entry)
+                }
+            }
+        }
+    }
+
+    /** Returns all [ResourceValue] for a single `entry`. */
+    private fun getAllResourceValues(entry: TypeChunk.Entry): Collection<ResourceValue> {
+        val values = HashSet<ResourceValue>()
+        entry.value()?.let { values.add(it) }
+        values.addAll(entry.values().values)
+        return values
+    }
+
+    private fun blameString(stringIndex: Int, entry: ResourceEntry) {
+        stringToBlame[stringIndex].add(entry)
+    }
+
+    /** Must first call [blame]. */
+    val keyToBlamedResources: Map<PackageChunk, Array<ArrayList<ResourceEntry>>>
+        get() = Collections.unmodifiableMap(keyToBlame)
+
+    /** Must first call [blame]. */
+    val typeToBlamedResources: Map<PackageChunk, Array<ArrayList<ResourceEntry>>>
+        get() = Collections.unmodifiableMap(typeToBlame)
+
+    /** Must first call [blame]. */
+    val packageToBlamedResources: Multimap<PackageChunk, ResourceEntry>
+        get() = Multimaps.unmodifiableMultimap(packageToBlame)
+
+    /** Must first call [blame]. */
+    val stringToBlamedResources: Array<ArrayList<ResourceEntry>>
+        get() = stringToBlame
+
+    /** Must first call [blame]. */
+    val typeEntryToBlamedResources: Multimap<TypeChunk.Entry, ResourceEntry>
+        get() = Multimaps.unmodifiableMultimap(typeEntryToBlame)
+
+    /** Returns a multimap of keys for which there is no default resource. */
+    fun getBaselessKeys(): Multimap<ResourceEntry, TypeChunk.Entry> {
+        baselessKeys?.let { return it }
+
+        val result = HashMultimap.create<ResourceEntry, TypeChunk.Entry>()
+        for ((resourceEntry, chunkEntries) in getResourceEntries().asMap()) {
+            if (!hasBaseConfiguration(chunkEntries)) {
+                result.putAll(resourceEntry, chunkEntries)
+            }
+        }
+        baselessKeys = result
+        return result
+    }
+
+    /** Returns a multimap of resource entries to the chunk entries they reference in this APK. */
+    fun getResourceEntries(): Multimap<ResourceEntry, TypeChunk.Entry> {
+        resourceEntries?.let { return it }
+
+        val result = HashMultimap.create<ResourceEntry, TypeChunk.Entry>()
+        for (typeChunk in getTypeChunks()) {
+            for (entry in typeChunk.entries.values) {
+                result.put(ResourceEntry.create(entry), entry)
+            }
+        }
+        resourceEntries = result
+        return result
+    }
+
+    /** Returns all [TypeChunk] in resources.arsc. */
+    fun getTypeChunks(): List<TypeChunk> {
+        typeChunks?.let { return it }
+
+        val result = ArrayList<TypeChunk>()
+        for (packageChunk in resourceTable.packages) {
+            result.addAll(packageChunk.typeChunks)
+        }
+        typeChunks = result
+        return result
+    }
+
+    private fun hasBaseConfiguration(entries: Collection<TypeChunk.Entry>): Boolean {
+        for (entry in entries) {
+            if (entry.parent().configuration.isDefault) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /** Describes a single resource entry. */
+    data class ResourceEntry(
+        val packageName: String,
+        val typeName: String,
+        val entryName: String
+    ) {
+        // 保留原有的同名函数以确保对旧 Java 代码调用的兼容性
+        fun packageName() = packageName
+        fun typeName() = typeName
+        fun entryName() = entryName
+
+        companion object {
+            @JvmStatic
+            fun create(entry: TypeChunk.Entry): ResourceEntry {
+                val packageChunk = checkNotNull(entry.parent().packageChunk)
+                val packageName = packageChunk.packageName
+                val typeName = entry.typeName()
+                val entryName = entry.key()
+                return ResourceEntry(packageName, typeName, entryName)
+            }
+        }
+    }
+
+    companion object {
+        private fun createEntryListArray(size: Int): Array<ArrayList<ResourceEntry>> {
+            // ~90-95% 的 list 最终只有 1 或 2 个元素，故初始化容量为 2
+            return Array(size) { ArrayList<ResourceEntry>(2) }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/org/tool/kit/utils/Utils.kt
+++ b/shared/src/commonMain/kotlin/org/tool/kit/utils/Utils.kt
@@ -5,13 +5,12 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import brut.xml.XmlUtils
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.core.FileAppender
-import com.google.devrel.gmscore.tools.apk.arsc.ArscBlamer
-import com.google.devrel.gmscore.tools.apk.arsc.BinaryResourceFile
-import com.google.devrel.gmscore.tools.apk.arsc.BinaryResourceIdentifier
+import com.google.devrel.gmscore.tools.apk.arsc.ResourceFile
+import com.google.devrel.gmscore.tools.apk.arsc.ResourceIdentifier
 import com.google.devrel.gmscore.tools.apk.arsc.ResourceTableChunk
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.vinceglb.filekit.FileKit
-import io.github.vinceglb.filekit.downloadDir
+import io.github.vinceglb.filekit.downloadsDir
 import io.github.vinceglb.filekit.path
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -79,7 +78,7 @@ private val logger = KotlinLogging.logger("Utils")
 /**
  * 获取下载目录
  */
-fun getDownloadDirectory() = FileKit.downloadDir.path
+fun getDownloadDirectory() = FileKit.downloadsDir.path
 
 val isWindows = System.getProperty("os.name").startsWith("Win")
 
@@ -268,17 +267,17 @@ suspend fun extractIcon(text: String?, apkPath: String, iconPath: String): Image
     }
 
 private fun extractBitmapFromResourceTable(apkPath: String, resourceId: Int): ImageBitmap? {
-    val binaryResourceIdentifier = BinaryResourceIdentifier.create(resourceId)
+    val binaryResourceIdentifier = ResourceIdentifier.create(resourceId)
 
     ZipFile(apkPath).use { zipFile ->
         val inputStream = zipFile.getZipFileInputStream("resources.arsc") ?: return null
-        val resourceFile = BinaryResourceFile.fromInputStream(inputStream)
+        val resourceFile = ResourceFile.fromInputStream(inputStream)
 
         val resourceTable = resourceFile.chunks.firstOrNull() as? ResourceTableChunk ?: return null
 
         val blamer = ArscBlamer(resourceTable).apply { blame() }
 
-        val matchingTypeChunk = blamer.typeChunks.lastOrNull { typeChunk ->
+        val matchingTypeChunk = blamer.getTypeChunks().lastOrNull { typeChunk ->
             typeChunk.containsResource(binaryResourceIdentifier) &&
                     typeChunk.configuration.density() in listOf(160, 240, 320, 480, 640)
         } ?: return null
@@ -286,7 +285,7 @@ private fun extractBitmapFromResourceTable(apkPath: String, resourceId: Int): Im
         val entry = matchingTypeChunk.entries[binaryResourceIdentifier.entryId()] ?: return null
         if (entry.isComplex) return null
 
-        val resourcePath = resourceTable.stringPool.getString(entry.value().data())
+        val resourcePath = resourceTable.stringPool.getString(entry.value()?.data() ?: 0)
         val resourceBytes = zipFile.getZipFileData(resourcePath) ?: return null
 
         return Image.makeFromEncoded(resourceBytes).toComposeImageBitmap()


### PR DESCRIPTION
- 升级项目版本至 1.6.11，并将 Gradle 包装器更新至 9.5.1。
- 升级多项核心库版本：Kotlin (2.4.0)、Coroutines (1.11.0)、Compose Plugin (1.11.1)、Ktor (3.5.0) 及其他第三方库。
- 新增 `ArscBlamer.kt` 以优化 APK 资源表（resources.arsc）的解析与图标提取逻辑。
- 重构“关于”页面的开源库展示逻辑，使用 `LibraryDetailMode.Sheet` 简化 UI 实现并移除冗余代码。
- 更新 ProGuard 混淆规则，新增对 Coroutines、dbus-java 及 FileKit 的保留规则。
- 修复了 `Utils.kt` 中因库 API 变更导致的兼容性问题。